### PR TITLE
use correct value in Error when stack is of len 1

### DIFF
--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -14,7 +14,7 @@ func Test(t *testing.T) {
 	s.Push(1)
 	
 	if s.Len() != 1 {
-		t.Errorf("Length should be 0")
+		t.Errorf("Length should be 1")
 	}
 	
 	if s.Peek().(int) != 1 {


### PR DESCRIPTION
minor aesthetic fix in stack_test.go 