### PR TITLE
Update stack_test.go

### DIFF
--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -14,7 +14,7 @@ func Test(t *testing.T) {
 	s.Push(1)
 	
 	if s.Len() != 1 {
-		t.Errorf("Length should be 0")
+		t.Errorf("Length should be 1")
 	}
 	
 	if s.Peek().(int) != 1 {


### PR DESCRIPTION
Error statement giving wrong output:
"Length should be 0" when error length is expected to be 1